### PR TITLE
restrict some suburls via nginx

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     environment:
       - HOST=sw360
       - HOST_PORT=8080
+      - RESTRICTED_URLS=manager|attachments|bdpimport|components|cvesearch|fossology|layouttpl|licenseinfo|licenses|moderation|projects|schedule|search|users|vendors|vulnerabilities
 
   sw360:
     build:

--- a/deployment/sw360nginx/docker-entrypoint.sh
+++ b/deployment/sw360nginx/docker-entrypoint.sh
@@ -44,6 +44,10 @@ server {
 
     server_name ${HOST}.localdomain;
 
+    location ~* /(${RESTRICTED_URLS})/ {
+        deny all;
+    }
+
     location / {
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;


### PR DESCRIPTION
A better solution would be, to move the backend services to another tomcat or to another Catalina configuration on the same tomcat, which listens on another port.
