### PR TITLE
Container for SW360 REST service added

### DIFF
--- a/deployment/docker-compose.rest-server.yml
+++ b/deployment/docker-compose.rest-server.yml
@@ -1,0 +1,33 @@
+# Copyright Bosch Software Innovations GmbH, 2016.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+
+# This file adds a cve-search server to the sw360 environment.
+# Use it together with the main docker-compose.yml as described
+# in README.md
+
+version: '2'
+services:
+
+  sw360restAuthorization:
+    extends:
+      file: sw360rest/common.yml
+      service: sw360restBase
+    command: /sw360rest/gradlew authorization-server:bootrun
+    ports:
+      - 8090:8090
+
+  sw360restResource:
+    extends:
+      file: sw360rest/common.yml
+      service: sw360restBase
+    command: /sw360rest/gradlew resource-server:bootrun
+    links:
+      - sw360
+    ports:
+      - 8091:8091

--- a/deployment/docker-compose.sh
+++ b/deployment/docker-compose.sh
@@ -28,6 +28,7 @@ fi
 
 DRY_RUN=${DRY_RUN:-false}
 DEV_MODE=${DEV_MODE:-false}
+REST=${REST:-false}
 CVE_SEARCH=${CVE_SEARCH:-false}
 HTTPS_COUCHDB=${HTTPS_COUCHDB:-false}
 
@@ -73,6 +74,7 @@ The environmental variables / inputs are set to
     DRY_RUN=$DRY_RUN
     DEV_MODE=$DEV_MODE
     CVE_SEARCH=$CVE_SEARCH
+    BACKUP_FOLDER=$BACKUP_FOLDER
 
 EOF
     exit 0
@@ -89,6 +91,7 @@ addSudoIfNeeded() {
 cmdDocker="$(addSudoIfNeeded) env $(grep -v '^#' proxy.env | xargs) docker"
 cmdDockerCompose="${cmdDocker}-compose -f $DIR/docker-compose.yml"
 [ "$DEV_MODE" == "true" ] && cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.dev.yml"
+[ "$REST" == "true" ] && cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.rest-server.yml"
 [ "$CVE_SEARCH" == "true" ] && cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.cve-search-server.yml"
 [ "$HTTPS_COUCHDB" == "true" ] && cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.couchdb-https.yml"
 

--- a/deployment/sw360rest/Dockerfile
+++ b/deployment/sw360rest/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright Bosch Software Innovations GmbH, 2016.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+FROM sw360baseimage
+MAINTAINER admin@sw360.org
+
+RUN . /usr/local/bin/setupProxy.sh && set -x \
+ && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
+ && $_update && $_install openjdk-8-jre openjdk-8-jdk git-core \
+ && apt-get update --fix-missing && $_install maven \
+ && $_cleanup \
+ && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
+ && echo "JAVA_HOME=\"/usr/lib/jvm/java-8-openjdk-amd64/jre\"" >> /etc/environment
+
+RUN mkdir -p /sw360rest
+WORKDIR /sw360rest
+COPY ./datahandler-1.6.0-SNAPSHOT.jar /tmp/
+RUN . /usr/local/bin/setupProxy.sh && set -x \
+ && mvn install:install-file -Dfile=/tmp/datahandler-1.6.0-SNAPSHOT.jar -DgroupId=org.eclipse.sw360 -DartifactId=datahandler -Dversion=1.6.0-SNAPSHOT -Dpackaging=jar \
+ && git clone https://github.com/sw360/sw360rest /sw360rest \
+ && sed -i 's/localhost/sw360/g' \
+    subprojects/resource-server/src/main/resources/application.yml \
+ && ./gradlew build
+
+EXPOSE 8090
+EXPOSE 8091

--- a/deployment/sw360rest/common.yml
+++ b/deployment/sw360rest/common.yml
@@ -6,7 +6,14 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-DEV_MODE=true
-# REST=false
-# CVE_SEARCH=false
-# HTTPS_COUCHDB=false
+version: '2'
+services:
+  sw360restBase:
+    build:
+      context: .
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sw360rest
+    restart: unless-stopped


### PR DESCRIPTION
Add docker containers which run the [sw360rest](https://github.com/sw360/sw360rest)-server. For this there are two services added to the docker-compose configuration, i.e.
- sw360restAuthorization, in which `./gradlew authorization-server:bootrun` is running and
- sw360restResource, in which `./gradlew resource-server:bootrun`.

## Before building the rest containers
One has to
-  enable rest in the `/deployment/configuration.env` file.
- place the file ` datahandler-1.6.0-SNAPSHOT.jar` (which is generated while compiling sw360) in `/deployment/sw360rest/`.

## How to get an authorization token
To get an authorization token one can run
```
$ docker exec -it deployment_sw360restAuthorization_1 ./gradlew printAccessToken
```

## Note
while building this clones sw360rest from github and thus needs configured proxy settings in some environments.