### PR TITLE
Add scripts to backup couchdb to JSON over HTTP

### DIFF
--- a/miscellaneous/backup/README.md
+++ b/miscellaneous/backup/README.md
@@ -1,0 +1,5 @@
+This folder contains two scripts, which are used to backup and restore the
+contents of the couchdb.
+
+They use the project `danielebailo/couchdb-dump`, which contains a script that
+is able to dump **and restore** the context of an database on couchdb as json.

--- a/miscellaneous/backup/backup.sh
+++ b/miscellaneous/backup/backup.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright Bosch Software Innovations GmbH, 2016.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+################################################################################
+# configuration
+
+host=localhost
+# user=sw360
+# password=sw360fossy
+
+backupDir="_backup/$(date +%F_%T)"
+
+################################################################################
+# preperation
+set -e
+cd $(dirname $0)
+DIR=$(pwd)
+mkdir -p "$backupDir"
+exec 1 | tee "$backupDir/$(basename $0).log"
+exec 2 | tee "$backupDir/$(basename $0).log"
+
+backupLast="_backup/last"
+echo "make backup to $backupDir"
+
+################################################################################
+# functions
+updateCouchdbDump() {
+    mkdir -p bin
+    curl https://raw.githubusercontent.com/danielebailo/couchdb-dump/master/couchdb-backup.sh > bin/couchdb-backup.sh
+    chmod +x bin/couchdb-backup.sh
+}
+
+backupDB() {
+    db=$1
+
+    cmd="bash ${DIR}/bin/couchdb-backup.sh -b -H $host -d $db -f $db.json"
+    if [ $user ];then
+        cmd="$cmd -u $user"
+        if [ $password ];then
+            cmd="$cmd -p $password"
+        fi
+    fi
+    $cmd
+}
+
+backupAllDBs() {
+    pushd $backupDir
+    for db in "sw360db" \
+              "sw360attachments" \
+              "sw360fossologykeys" \
+              "sw360users" \
+              "sw360vm"; do
+        backupDB $db && {
+            sha256sum "$db.json" > "$db.json.sha256"
+            md5sum "$db.json" > "$db.json.md5"
+            du "$db.json" > "$db.json.size"
+        } || {
+            echo "ERROR: $db backup failed"
+            if [ -f "$db.json" ]; then
+                mkdir -p failed
+                mv "$db.json" failed
+            fi
+        }
+    done
+    popd
+}
+
+################################################################################
+# do the backup
+
+updateCouchdbDump
+backupAllDBs
+rm $backupLast || true
+ln -s $DIR/$backupDir $backupLast

--- a/miscellaneous/backup/restore.sh
+++ b/miscellaneous/backup/restore.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright Bosch Software Innovations GmbH, 2016.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+set -e
+
+################################################################################
+# configuration
+
+host=localhost
+# user=sw360
+# password=sw360fossy
+
+if [ $1 ] && [ -d $1 ]; then
+    backupDir=$1
+else
+    backupDir="_backup/last"
+fi
+
+################################################################################
+# preperation
+set -e
+cd $(dirname $0)
+DIR=$(pwd)
+exec 1 | tee "$backupDir/$(basename $0).log"
+exec 2 | tee "$backupDir/$(basename $0).log"
+
+################################################################################
+# functions
+updateCouchdbDump() {
+    mkdir -p bin
+    curl https://raw.githubusercontent.com/danielebailo/couchdb-dump/master/couchdb-backup.sh > bin/couchdb-backup.sh
+    chmod +x bin/couchdb-backup.sh
+}
+
+restore() {
+    jsonFile=$1
+    jsonBasename=$(basename $jsonFile)
+    db=${jsonBasename%.json}
+
+    echo "restore db $db"
+
+    #create the db
+    dbCreationOutput=$(curl -X PUT "http://${host}:5984/${db}")
+    if [[ "$dbCreationOutput" = *"\"ok\":true"* ]]; then
+        # backup the data
+        cmd="bash ${DIR}/bin/couchdb-backup.sh -r -H $host -d $db -f $jsonFile"
+        if [ $user ]; then
+            cmd="$cmd -u $user"
+            if [ $password ]; then
+                cmd="$cmd -p $password"
+            fi
+        fi
+        $cmd || {
+            echo "ERROR: $jsonFile restore failed"
+        }
+    else
+        echo "ERROR: while creating the db $db: $dbCreationOutput"
+    fi
+}
+
+restoreAll() {
+    for jsonFile in $backupDir/*.json; do
+        restore $jsonFile
+    done
+}
+
+################################################################################
+# do the restore
+
+updateCouchdbDump
+restoreAll


### PR DESCRIPTION
This commit contains two scripts, which are used to backup and restore the
contents of the couchdb.

They use the project `danielebailo/couchdb-dump`, which contains a script that
is able to dump **and restore** the context of an database on couchdb as json.