### PR TITLE
cve-search: checkout specific version

### DIFF
--- a/deployment/cve-search-server/Dockerfile
+++ b/deployment/cve-search-server/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /cve-search
 run if [ "$http_proxy" = "None" ]; then unset http_proxy; fi && if [ "$https_proxy" = "None" ]; then unset https_proxy; fi \
  && set -x \
  && git clone https://github.com/cve-search/cve-search /cve-search \
+ && (git checkout 7a000ec5e27cc765d80470d5d28a4cc59000d108 2>&1) \
  && pip3 install -q -U pip \
  && pip install -r requirements.txt \
  && cp etc/configuration.ini.sample etc/configuration.ini \


### PR DESCRIPTION
current master has a changed api and does no longer work with our implementanion. So this PR pins down the last commit that works with our implementation and checks out this one.