### PR TITLE
chore(docker): make missing option configurable

### DIFF
--- a/deployment/configuration.yml
+++ b/deployment/configuration.yml
@@ -175,6 +175,9 @@ services:
     #  - COUCHDB_PASSWORD=sw360fossy
     volumes:
       - ./_couchdb:/usr/local/var/lib/couchdb
+  sw360couchdb-lucene:
+    # environment:
+    #  - COUCHDB_PASSWORD=sw360fossy
 
 
   ##############################################################################

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       - sw360couchdb
     environment:
       - COUCHDB_HOST=sw360couchdb
+      - COUCHDB_USER=sw360
 
 networks:
   sw360front:


### PR DESCRIPTION
Until now one had to add to lucene the configuration for the Couchdb password by hand. This adds the corresponding template