### PR TITLE
chore(docker): replace utility by build-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ _*
 .vagrant
 *.tar.gz
 *.deb
+*.zip
 *.rpm
 .idea

--- a/packaging/rake/docker.rb
+++ b/packaging/rake/docker.rb
@@ -19,8 +19,8 @@ namespace :docker do
     volume="-v #{ROOT}:/sw360chore"
     volume << " -v #{OUTPUT_DIR}:/sw360chore/_output"
     workdir="-w /sw360chore"
-    gosu="gosu $(id -u):$(id -g)"
-    sh "docker run -i #{volume} #{workdir} sw360/#{DEV_CONTAINER_NAME} #{gosu} #{cmd}"
+    chroot="chroot --userspec=$(id -u):$(id -g) --skip-chdir /"
+    sh "docker run -i #{volume} #{workdir} sw360/#{DEV_CONTAINER_NAME} #{chroot} #{cmd}"
   end
 
   desc "build the container and predeploy the wars in it"

--- a/packaging/sw360packager.Dockerfile
+++ b/packaging/sw360packager.Dockerfile
@@ -19,16 +19,6 @@ ENV _cleanup="eval apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/
 ENV _purge="apt-get purge -y --auto-remove"
 
 RUN set -x \
- && $_update && $_install ca-certificates wget && $_cleanup \
- && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
- && chmod +x /usr/local/bin/gosu \
- && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
- && export GNUPGHOME="$(mktemp -d)" \
- && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
- && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
- && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && $_purge ca-certificates
-
-RUN set -x \
  # && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list \
  && echo "deb http://ppa.launchpad.net/openjdk-r/ppa/ubuntu xenial main" > /etc/apt/sources.list.d/backports.list \
  && $_update && $_install openjdk-8-jdk wget maven && $_cleanup \


### PR DESCRIPTION
The tool gosu, which was used until now, is not necessary