### PR TITLE
feat(dev): serve tomcat logs under `https://localhost:8443/logs` in dev mode

### DIFF
--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -21,6 +21,7 @@ services:
       - 5005:5005
     environment:
       - TOMCAT_DEBUG_PORT=5005
+      - SERVE_LOGS=1
   sw360postgres:
     ports:
       - 5432:5432

--- a/deployment/sw360/docker-entrypoint.sh
+++ b/deployment/sw360/docker-entrypoint.sh
@@ -10,6 +10,9 @@
 
 # the used / parsed environmental variables are:
 #
+# to serve the tomcat logs under /logs
+#    $SERVE_LOGS
+#
 # for postgres configuration
 #    $POSTGRES_HOST (defaults to: "localhost")
 #    $POSTGRES_USER (optional)
@@ -38,6 +41,14 @@
 #    $LDAP_CREDENTIALS (e.g. Password)
 
 set -e
+
+if [ "$SERVE_LOGS" ]; then
+    cat <<EOF > /opt/sw360/conf/Catalina/localhost/logs.xml
+<Context override="true" docBase="/opt/sw360/logs/" path="/logs" />
+EOF
+else
+    rm -f /opt/sw360/conf/Catalina/localhost/logs.xml
+fi
 
 ################################################################################
 # Setup postgres


### PR DESCRIPTION
This allows someone managing a remote installation of SW360 to view tomcats `catalina.out` under `https://DOMAIN.TLD:8443/logs/catalina.out`.

This is only active in the dev mode.