### PR TITLE
feat(docker): webapps as volume

### DIFF
--- a/deployment/configuration.yml
+++ b/deployment/configuration.yml
@@ -170,6 +170,7 @@ services:
 
     volumes:
       - ./_deploy:/opt/sw360/deploy
+      # - ./_webapps:/opt/sw360/webapps
       - ./_logs:/opt/sw360/logs
 
   sw360postgres:

--- a/deployment/docker-compose.sh
+++ b/deployment/docker-compose.sh
@@ -255,6 +255,10 @@ elif [ "$1" == "--backup" ]; then
 elif [ "$1" == "--restore" ]; then
     restore
 else
+    mkdir -p "$DIR/_couchdb"
+    mkdir -p "$DIR/_deploy"
+    mkdir -p "$DIR/_webapps"
+    mkdir -p "$DIR/_logs"
     cmdDockerCompose="$cmdDockerCompose $*"
     $cmdDockerCompose
 fi

--- a/deployment/sw360/Dockerfile
+++ b/deployment/sw360/Dockerfile
@@ -22,15 +22,19 @@ ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
 ADD sw360_dependencies.tar.gz /opt
 RUN set -x\
  && rm -rf $CATALINA_HOME/webapps/examples \
-            $CATALINA_HOME/webapps/docs \
-            $CATALINA_HOME/webapps/manager \
-            $CATALINA_HOME/webapps/host-manager \
-            $CATALINA_HOME/webapps/couchdb-lucene*war \
-            $CATALINA_HOME/webapps/ROOT \
-            $CATALINA_HOME/RELEASE-NOTES \
-            $CATALINA_HOME/RUNNING.txt \
-            $CATALINA_HOME/bin/*.bat \
-            $CATALINA_HOME/bin/*.tar.gz
+           $CATALINA_HOME/webapps/docs \
+           $CATALINA_HOME/webapps/manager \
+           $CATALINA_HOME/webapps/host-manager \
+           $CATALINA_HOME/webapps/couchdb-lucene*war \
+           $CATALINA_HOME/RELEASE-NOTES \
+           $CATALINA_HOME/RUNNING.txt \
+           $CATALINA_HOME/bin/*.bat \
+           $CATALINA_HOME/bin/*.tar.gz \
+ && ( \
+   cd $CATALINA_HOME/webapps/ \
+   && tar -zcf $CATALINA_HOME/ROOT.tar.gz ROOT \
+ ) \
+ && rm -rf $CATALINA_HOME/webapps/ROOT
 
 VOLUME [ "/opt/sw360" ]
 

--- a/deployment/sw360/docker-entrypoint.sh
+++ b/deployment/sw360/docker-entrypoint.sh
@@ -39,6 +39,10 @@
 
 set -e
 
+if [ ! -d /opt/sw360/webapps/ROOT ]; then
+    tar -zxf /opt/sw360/ROOT.tar.gz -C /opt/sw360/webapps/
+fi
+
 ################################################################################
 # Setup postgres
 sed -i 's/jdbc.default.url=.*/jdbc.default.url=jdbc:postgresql:\/\/'"${POSTGRES_HOST:-localhost}"':5432\/sw360pgdb/g' \


### PR DESCRIPTION
This PR allows to to access tomcats `webapps`-folder via the folder `deployment/_webapps`.

This allows for a faster and more stable deployment. (since the liferay deployment sometimes throws zip-exceptions)

This also makes the the setup more complicated by adding another point of persistence. To prevent this, this feature is disabled by default (see: https://github.com/sw360/sw360chores/pull/29/files#diff-74ad5c8cbff3d546dffe8977d31cdf3aR175)