### PR TITLE
fix(nginx): fix url matching

### DIFF
--- a/deployment/sw360nginx/docker-entrypoint.sh
+++ b/deployment/sw360nginx/docker-entrypoint.sh
@@ -58,7 +58,7 @@ server {
 
     server_name ${HOST}.localdomain;
 
-    location ~* /(${RESTRICTED_URLS})/ {
+    location ~* ^/(${RESTRICTED_URLS})/ {
         deny all;
     }
 


### PR DESCRIPTION
The old pattern prevents url keywords like 'components' even
if the url did not start with this name.

This prevents folders like 'components' even in the 'js' subdirectory.
This fix only prevents urls that starts with one of the keywords.