### PR TITLE
feat(cve-search): always start https on port 5443

### DIFF
--- a/deployment/docker-compose.cve-search-server.yml
+++ b/deployment/docker-compose.cve-search-server.yml
@@ -14,11 +14,29 @@
 version: '2'
 services:
 
+  sw360nginxCvesearch:
+    build: ./sw360nginx/
+    image: sw360nginx
+    restart: unless-stopped
+    ports:
+      - 5443:8443
+    networks:
+      - sw360front
+    depends_on:
+      - sw360cvesearch
+    environment:
+      - HOST=sw360cvesearch
+      - HOST_PORT=5000
+    extends:
+      file: configuration.yml
+      service: sw360nginx
+
   sw360:
     depends_on:
       - sw360cvesearch
     environment:
       - CVE_SEARCH_HOST=http://sw360cvesearch:5000
+
   sw360cvesearch:
     extends:
       file: cve-search-server/common.yml


### PR DESCRIPTION
This adds another nginx which is used to offer an https connection to the cve-search ui via the port `5443`. The "regular" http connection is still open on `5000`.