### PR TITLE
feat(rest): use containers from sw360rest project

### DIFF
--- a/deployment/configuration.env
+++ b/deployment/configuration.env
@@ -7,6 +7,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 DEV_MODE=true
+# REST=false
 # CVE_SEARCH=false
 # HTTPS_COUCHDB=false
 # BACKUP_FOLDER=./_backup

--- a/deployment/docker-compose.rest.yml
+++ b/deployment/docker-compose.rest.yml
@@ -1,0 +1,30 @@
+# Copyright Bosch Software Innovations GmbH, 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+
+# This file adds a cve-search server to the sw360 environment.
+# Use it together with the main docker-compose.yml as described
+# in README.md
+
+version: '2'
+services:
+  sw360-authorization-server:
+    image: sw360rest-authorization-server
+    ports:
+      - 8090:8090
+    environment:
+      - SW360_AUTHORIZATION_SERVER_ARGS=-Dspring.profiles.active=dev
+
+  sw360-resource-server:
+    image: sw360rest-resource-server
+    ports:
+      - 8091:8091
+    networks:
+      - sw360front
+    environment:
+      - SW360_THRIFT_SERVER_URL=http://sw360:8080

--- a/deployment/docker-compose.sh
+++ b/deployment/docker-compose.sh
@@ -92,6 +92,7 @@ addSudoIfNeeded() {
 cmdDocker="$(addSudoIfNeeded) env $(grep -v '^#' proxy.env | xargs) docker"
 cmdDockerCompose="${cmdDocker}-compose -f $DIR/docker-compose.yml"
 [ "$DEV_MODE" == "true" ] && cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.dev.yml"
+[ "$REST" == "true" ] && cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.rest.yml"
 [ "$CVE_SEARCH" == "true" ] && {
     cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.cve-search-server.yml"
     [ "$DEV_MODE" == "true" ] && cmdDockerCompose="$cmdDockerCompose -f $DIR/docker-compose.dev.cve-search-server.yml"


### PR DESCRIPTION
If one has build the containers (via `docker-compose build`) from sw360/sw360rest, one can start them in sw360chores via setting `REST=true` in `configuration.env`.