### PR TITLE
feat(docker-compose.sh): add cleanup functionallity

### DIFF
--- a/deployment/couchdb-lucene/cleanup.sh
+++ b/deployment/couchdb-lucene/cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Copyright Bosch Software Innovations GmbH, 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# This script invokes the building of the dependency package required by
+# sw360 and places it into the sw360 folder.
+
+set -e
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rm "$DIR/couchdb-lucene-"*"-dist.zip" || true

--- a/deployment/cve-search-server/cleanup.sh
+++ b/deployment/cve-search-server/cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Copyright Bosch Software Innovations GmbH, 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# This script invokes the building of the dependency package required by
+# sw360 and places it into the sw360 folder.
+
+set -e
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rm "$DIR/cve-search@"*".tar.gz" || true

--- a/deployment/sw360/cleanup.sh
+++ b/deployment/sw360/cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Copyright Bosch Software Innovations GmbH, 2017.
+# Part of the SW360 Portal Project.
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# This script invokes the building of the dependency package required by
+# sw360 and places it into the sw360 folder.
+
+set -e
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
+rm "$DIR/sw360_dependencies.tar.gz" || true


### PR DESCRIPTION
This PR allows the `./docker-compos.sh` script to
- remove all docker containers and docker images related to the current docker-compose configuration with `--cleanup` or
- also remove the results of `--prapare` by running `--cleanup-all`

It might be good to also add functionallity to cleanup `_logs`, `_couhdb` and co.