### PR TITLE
fix(couchdb-lucene): configuration.yml was not used for lucene container

### DIFF
--- a/deployment/couchdb-lucene/docker-entrypoint.sh
+++ b/deployment/couchdb-lucene/docker-entrypoint.sh
@@ -8,7 +8,7 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-set -ex
+set -e
 
 if [ ! "$COUCHDB_HOST" ]; then
     echo "the environmental variable \$COUCHDB_HOST must be set"

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -98,6 +98,9 @@ services:
     environment:
       - COUCHDB_HOST=sw360couchdb
       - COUCHDB_USER=sw360
+    extends:
+      file: configuration.yml
+      service: sw360couchdb-lucene
 
 networks:
   sw360front:


### PR DESCRIPTION
This resulted in the problem, that lucene did not work if couchdb auth was enabled.