### PR TITLE
fix sw360populated/Dockerfile

### DIFF
--- a/docker-images/sw360populated/Dockerfile
+++ b/docker-images/sw360populated/Dockerfile
@@ -14,7 +14,7 @@ COPY _deploy/liferay/* /opt/sw360/deploy/liferay/
 RUN set -ex \
  && for war in /opt/sw360/deploy/tomcat/*.war; do \
       folder=$(basename $war .war); \
-      mkdir -p /opt/sw360/tomcat-*/webapps/$folder; \
-      unzip -q $war -d /opt/sw360/tomcat-*/webapps/$folder; \
+      mkdir -p /opt/sw360/tomcat-9.0.17/webapps/$folder; \
+      unzip -q $war -d /opt/sw360/tomcat-9.0.17/webapps/$folder; \
       rm $war; \
     done


### PR DESCRIPTION
The wildcard in "tomcat-*/webapps/$folder" is not expanded since
this folder does not exist yet at this point.  Use "tomcat-9.0.17"
as like as the sw360empty/Dockerfile.

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>