### PR TITLE
get rid of hardcoded tomcat version from Dockerfiles

### DIFF
--- a/docker-images/sw360empty/Dockerfile
+++ b/docker-images/sw360empty/Dockerfile
@@ -21,4 +21,4 @@ COPY tomcatdeploy.sh /usr/local/bin/tomcatdeploy.sh
 COPY docker-entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["tail", "-f", "/opt/sw360/tomcat-9.0.17/logs/catalina.out"]
+CMD tail -f /opt/sw360/$TOMCAT/logs/catalina.out

--- a/docker-images/sw360populated/Dockerfile
+++ b/docker-images/sw360populated/Dockerfile
@@ -14,7 +14,7 @@ COPY _deploy/liferay/* /opt/sw360/deploy/liferay/
 RUN set -ex \
  && for war in /opt/sw360/deploy/tomcat/*.war; do \
       folder=$(basename $war .war); \
-      mkdir -p /opt/sw360/tomcat-*/webapps/$folder; \
-      unzip -q $war -d /opt/sw360/tomcat-*/webapps/$folder; \
+      mkdir -p /opt/sw360/tomcat-9.0.17/webapps/$folder; \
+      unzip -q $war -d /opt/sw360/tomcat-9.0.17/webapps/$folder; \
       rm $war; \
     done

--- a/docker-images/sw360populated/Dockerfile
+++ b/docker-images/sw360populated/Dockerfile
@@ -14,7 +14,8 @@ COPY _deploy/liferay/* /opt/sw360/deploy/liferay/
 RUN set -ex \
  && for war in /opt/sw360/deploy/tomcat/*.war; do \
       folder=$(basename $war .war); \
-      mkdir -p /opt/sw360/tomcat-9.0.17/webapps/$folder; \
-      unzip -q $war -d /opt/sw360/tomcat-9.0.17/webapps/$folder; \
+      (cd /opt/sw360/tomcat-*; \
+       mkdir -p webapps/$folder; \
+       unzip -q $war -d webapps/$folder); \
       rm $war; \
     done


### PR DESCRIPTION
Get rid of "tomcat-9.0.17" from Dockerfiles.
This reqeest includes pull request #66 (fix sw360populated/Dockerfile).
