### PR TITLE
chore: replace `.gitkeep` by `mkdir -p` call

### DIFF
--- a/miscellaneous/prepare-liferay/prepare.sh
+++ b/miscellaneous/prepare-liferay/prepare.sh
@@ -37,6 +37,7 @@ if [[ $1 == "--cleanup" ]]; then
 fi
 
 if [ ! -f "$TARGET" ]; then
+    mkdir -p downloads
     cd downloads
 
     if [ ! -f "$LIFERAY" ]; then


### PR DESCRIPTION
Previously there was a folder `miscellaneous/prepare-liferay/downloads/` which was preserved in git by a `.gitkeep`. I have now seen multiple people removing that folder for cleanup and thus creating conflicts. This PR prevents that issue by always creating this folder on demand.