### PR TITLE
fix backend deployment on non-productive mode

### DIFF
--- a/sw360chores.pl
+++ b/sw360chores.pl
@@ -636,6 +636,6 @@ if (defined $ARGV[0]) {
 }
 
 if (! $prod) {
-    copyToSW360Container($cpWebappsDir, "/opt/sw360/webapps") if $cpWebappsDir;
-    copyToSW360Container($cpDeployDir, "/opt/sw360/deploy") if $cpDeployDir;
+    copyToSW360Container($cpWebappsDir, "/opt/sw360/deploy/tomcat") if $cpWebappsDir;
+    copyToSW360Container($cpDeployDir, "/opt/sw360/deploy/liferay") if $cpDeployDir;
 }


### PR DESCRIPTION
With the upgrade to Liferay 7, deployment directories were changed
like this (in productive mode):

/opt/sw360/webapps => /opt/sw360/deploy/tomcat
/opt/sw360/deploy => /opt/sw360/deploy/liferay

Fix non-productive mode deployment according to this change.

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>