### PR TITLE
fix(tomcat): Make hot-deployment work reliably

### DIFF
--- a/docker-images/sw360empty/tomcatdeploy.sh
+++ b/docker-images/sw360empty/tomcatdeploy.sh
@@ -41,6 +41,7 @@ echo -e "\n========================"
 echo "Start watching for events [close_write] in [$WATCH_DIR] on $(date)"
 echo "========================"
 
+mkdir -p "$WATCH_DIR"
 echo -n "Starting: "
 echo inotifywait --quiet --monitor --event close_write --recursive --format '%w%f' "$WATCH_DIR"
 


### PR DESCRIPTION
This change makes sure that the directory to be watched for changes in
the deployment actually exists. This seems to be necessary, as otherwise
no deployment is done.

Resolves #77
