### PR TITLE
Improve proxy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _*
 .idea
 *.war
 /miscellaneous/prepare-liferay/downloads
+/configuration/proxy.env

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ configuration
 │   ├── nginx.pem
 │   └── regenerateCerts.sh
 ├── POSTGRES_PASSWORD
-├── proxy.env
+├── proxy.env.template
 └── sw360
     ├── sw360.env
     ├── fossology
@@ -97,8 +97,11 @@ There is also the file `./configuration/nginx/regenerateCerts.sh`, which is used
 #### The file `./configuration/POSTGRES_PASSWORD`
 This file just contains the password for postgres and it is added as secret to the containers.
 
-#### The file `./configuration/proxy.env`
-Here one can add proxy settings, which are passed to all docker-compose calls and into the containers, which need to connect to the internet.
+#### The file `./configuration/proxy.env.template`
+This is a template file for configuring proxy settings. To enable support for a proxy, copy this file to a file named `proxy.env` (in
+the same folder). In `proxy.env` one can add proxy settings, which are passed to all docker-compose calls and into the containers, which need to connect to the internet.
+
+_Note:_ The file `proxy.env` is excluded from source control; so it is not shown as outgoing changes.
 
 #### The folder `./configuration/sw360/`
 

--- a/configuration/proxy.env.template
+++ b/configuration/proxy.env.template
@@ -6,8 +6,13 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
+# Template for a proxy configuration file. This file provides a
 # common environment for adding proxy settings, sourced by containers which need
-# to talk to the outside while running
+# to talk to the outside while running.
+# In order to activate proxy settings, create a copy of this template under the
+# name 'proxy.env' and adapt the properties according to your needs.
+# (The file proxy.env is excluded from version control; so a 'git status'
+# command will show no modifications.)
 
 #proxy_host=myproxy.example.invalid
 #proxy_port=8080

--- a/sw360chores.pl
+++ b/sw360chores.pl
@@ -164,6 +164,12 @@ if($debug) {
     say STDERR "    \@ARGV         = @ARGV";
 }
 
+# create proxy.env file from template if it does not exist yet
+if (not -e "configuration/proxy.env") {
+    say "INFO: creating proxy.env from template.";
+    copy ("configuration/proxy.env.template", "configuration/proxy.env");
+}
+
 ################################################################################
 my $imagesSrcDir = "./docker-images";
 my $saveDir = "./_images";


### PR DESCRIPTION
This PR addresses #79. It implements the following changes:

* The proxy.env configuration file is now provided as a template. The user can copy the template and modify it. The file `proxy.env` has been added to .gitignore; so it does not appear as outgoing change.
* The sw360chores.pl script now supports a new command line switch --net-host. If specified, when building docker images the network mode 'host' is enabled. This allows the containers to access the internet (e.g. when installing additional packages) when behind a proxy.